### PR TITLE
Fixing failing tests.

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -73,13 +73,15 @@ func (g1 Game) IsEqual(g2 Game) bool {
 	equalStacks := g1.Stacks.IsEqual(g2.Stacks)
 	equalBoard := g1.Board.IsEqual(g2.Board)
 	equalCurrentCardIndex := g1.CurrentCardIndex == g2.CurrentCardIndex
+	equalFlipCount := g1.FlipCount == g2.FlipCount
 	if g1.Debug {
 		fmt.Printf("cards: %v\n", equalCards)
 		fmt.Printf("stacks: %v\n", equalStacks)
 		fmt.Printf("board: %v\n", equalBoard)
 		fmt.Printf("index: %v\n", equalCurrentCardIndex)
+		fmt.Printf("flip count: %v\n", equalFlipCount)
 	}
-	if equalCards && equalStacks && equalBoard && equalCurrentCardIndex {
+	if equalCards && equalStacks && equalBoard && equalCurrentCardIndex && equalFlipCount {
 		return true
 	}
 	return false

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -126,6 +126,36 @@ func TestNextDeckCard(t *testing.T) {
 
 }
 
+func TestSetFlipcount(t *testing.T) {
+	g := NewGame()
+
+	err := g.SetFlipCount(1)
+	if err != nil {
+		t.Error("Expected no error.")
+	}
+	if g.FlipCount != 1 {
+		t.Error("Expected flip count to be 1.", g.FlipCount)
+	}
+
+	err = g.SetFlipCount(3)
+	if err != nil {
+		t.Error("Expected no error.")
+	}
+	if g.FlipCount != 3 {
+		t.Error("Expected flip count to be 3.", g.FlipCount)
+	}
+
+	err = g.SetFlipCount(0)
+	if err.Error() != "flip count must be 1 or 3" {
+		t.Error("Expected error message not shown.")
+	}
+
+	err = g.SetFlipCount(-1)
+	if err.Error() != "flip count must be 1 or 3" {
+		t.Error("Expected error message not shown.")
+	}
+}
+
 func TextCheckMove(t *testing.T) {
 
 }
@@ -134,8 +164,8 @@ func TestDeepCopy(t *testing.T) {
 	game := NewGame()
 	gameShallow := game
 	gameDeep := game.DeepCopy()
-
 	// Checking each part of the game Cards, Board, Stacks, CurrentCardIndex and FlipCount
+	game.CurrentCardIndex = 0
 	testutils.AssertNoError(t, game.MoveFromDeckToStacks(), "MoveFromDeckToStacks")
 	if !game.Cards[0].IsEqual(gameShallow.Cards[0]) {
 		t.Error("Shallow copies behave unexpectedly.  If you need to make a copy of game, use deep copy.")
@@ -168,6 +198,13 @@ func TestDeepCopy(t *testing.T) {
 		t.Error("Deep copy should not be updated when original is updated.")
 	}
 
+	testutils.AssertNoError(t, game.SetFlipCount(1), "FlipCount")
+	if game.IsEqual(gameShallow) {
+		t.Error("Shallow copies behave unexpectedly.  If you need to make a copy of game, use deep copy.")
+	}
+	if game.IsEqual(gameDeep) {
+		t.Error("Deep copy should not be updated when original is updated.")
+	}
 	// TODO: Test CurrentCardIndex and FlipCount
 }
 

--- a/game/gamestates/gamestates_test.go
+++ b/game/gamestates/gamestates_test.go
@@ -184,8 +184,6 @@ func TestUndo(t *testing.T) {
 
 	stateSize := len(gs.States)
 	undoState := gs.Undo()
-	prevGame.Print()
-	undoState.Print()
 	if len(gs.States) != stateSize-1 {
 		t.Error("State size should have been reduced by 1 after undo.")
 	}

--- a/game/gamestates/gamestates_test.go
+++ b/game/gamestates/gamestates_test.go
@@ -10,7 +10,8 @@ type Game game.Game
 
 // Helper function to create a simple test game state
 func createTestGameState() game.Game {
-	return game.NewGame()
+	game := game.NewGame()
+	return game
 }
 
 // func (g1 Game) compareTo(g2 game.Game) bool {
@@ -70,65 +71,80 @@ func TestSaveState(t *testing.T) {
 	gs := NewGameStates()
 	game := createTestGameState()
 	game.DealBoard()
+	// game.CurrentCardIndex = 0
 	gs.SaveState(game)
 
 	if len(gs.States) != 1 {
 		t.Error("Expected 1 state after SaveState()")
 	}
+
 	testutils.AssertNoError(t, game.MoveFromBoardToStacks(0), "Move Board to Stacks failed")
 	gs.SaveState(game)
 	if len(gs.States) != 2 {
 		t.Error("Expected 2 states after SaveState()")
 	}
-	if game.IsEqual(gs.States[0]) {
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
 		t.Error("Saved state is not a deep copy of the original state")
 	}
+
 	testutils.AssertNoError(t, game.MoveFromBoardToStacks(2), "Move board to stack failed")
 	gs.SaveState(game)
+
 	testutils.AssertNoError(t, game.MoveFromColumnToColumn(2, 4), "Move column to colum")
 	gs.SaveState(game)
-	if game.IsEqual(gs.States[2]) {
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
 		t.Error("Saved state is not a deep copy of the original state")
 	}
+
 	testutils.AssertNoError(t, game.MoveFromColumnToColumn(5, 0), "")
 	gs.SaveState(game)
-	if game.IsEqual(gs.States[3]) {
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
 		t.Error("Saved state is not a deep copy of the original state")
 	}
+
+	testutils.AssertNoError(t, game.MoveFromDeckToBoard(3), "Move deck to board")
+	gs.SaveState(game)
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
+		t.Error("Saved state is not a deep copy of the original state")
+	}
+
 	testutils.AssertNoError(t, game.NextDeckCard(), "")
 	gs.SaveState(game)
-	if game.IsEqual(gs.States[4]) {
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
 		t.Error("Saved state is not a deep copy of the original state")
 	}
+
 	testutils.AssertNoError(t, game.NextDeckCard(), "")
 	gs.SaveState(game)
 	testutils.AssertNoError(t, game.NextDeckCard(), "")
 	gs.SaveState(game)
-	testutils.AssertNoError(t, game.MoveFromDeckToBoard(0), "Move deck to board")
+
+	testutils.AssertNoError(t, game.MoveFromDeckToStacks(), "Move deck to stacks")
 	gs.SaveState(game)
-	if game.IsEqual(gs.States[7]) {
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
 		t.Error("Saved state is not a deep copy of the original state")
 	}
-	testutils.AssertNoError(t, game.MoveFromColumnToColumn(5, 0), "")
+
+	testutils.AssertNoError(t, game.NextDeckCard(), "")
 	gs.SaveState(game)
-	testutils.AssertNoError(t, game.MoveFromColumnToColumn(5, 4), "")
+
+	testutils.AssertNoError(t, game.MoveFromDeckToBoard(3), "Move deck to board")
 	gs.SaveState(game)
-	testutils.AssertNoError(t, game.NextDeckCard(), "Next card")
-	gs.SaveState(game)
-	testutils.AssertNoError(t, game.MoveFromDeckToBoard(2), "Move deck to board")
-	gs.SaveState(game)
-	testutils.AssertNoError(t, game.MoveFromDeckToStacks(), "Move deck to stack")
-	gs.SaveState(game)
-	if game.IsEqual(gs.States[12]) {
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
 		t.Error("Saved state is not a deep copy of the original state")
 	}
-	testutils.AssertNoError(t, game.MoveFromColumnToColumn(2, 5), "Move column to column")
+
+	testutils.AssertNoError(t, game.MoveFromColumnToColumn(2, 3), "")
 	gs.SaveState(game)
-	testutils.AssertNoError(t, game.MoveFromDeckToBoard(2), "Move deck to board")
+
+	testutils.AssertNoError(t, game.SetFlipCount(1), "Set Flip Count to 1")
 	gs.SaveState(game)
-	testutils.AssertNoError(t, game.SetFlipCount(1), "Set flip count to 1")
-	gs.SaveState(game)
-	// TODO: Finish testing SetFlipCount.
+	if game.IsEqual(gs.States[len(gs.States)-2]) {
+		t.Error("Saved state is not a deep copy of the original state")
+	}
+	if gs.States[len(gs.States)-1].FlipCount != 1 {
+		t.Error("Flip count should be 1")
+	}
 }
 
 func TestUndo(t *testing.T) {
@@ -146,29 +162,25 @@ func TestUndo(t *testing.T) {
 	gs.SaveState(game)
 	game.MoveFromColumnToColumn(5, 0)
 	gs.SaveState(game)
-	game.NextDeckCard()
+	game.MoveFromDeckToBoard(3)
 	gs.SaveState(game)
 	game.NextDeckCard()
 	gs.SaveState(game)
 	game.NextDeckCard()
 	gs.SaveState(game)
-	game.MoveFromDeckToBoard(0)
-	gs.SaveState(game)
-	game.MoveFromColumnToColumn(5, 0)
-	gs.SaveState(game)
-	game.MoveFromColumnToColumn(5, 4)
-	gs.SaveState(game)
 	game.NextDeckCard()
-	gs.SaveState(game)
-	game.MoveFromDeckToBoard(2)
 	gs.SaveState(game)
 	game.MoveFromDeckToStacks()
 	gs.SaveState(game)
-	game.MoveFromColumnToColumn(2, 5)
+	game.NextDeckCard()
+	gs.SaveState(game)
+	game.MoveFromDeckToBoard(3)
+	gs.SaveState(game)
+	game.MoveFromColumnToColumn(2, 3)
+	gs.SaveState(game)
+	game.SetFlipCount(1)
+	gs.SaveState(game)
 	prevGame := game.DeepCopy()
-	gs.SaveState(game)
-	game.MoveFromDeckToBoard(2)
-	gs.SaveState(game)
 
 	stateSize := len(gs.States)
 	undoState := gs.Undo()

--- a/game/gamestates/gamestates_test.go
+++ b/game/gamestates/gamestates_test.go
@@ -178,9 +178,9 @@ func TestUndo(t *testing.T) {
 	gs.SaveState(game)
 	game.MoveFromColumnToColumn(2, 3)
 	gs.SaveState(game)
+	prevGame := game.DeepCopy()
 	game.SetFlipCount(1)
 	gs.SaveState(game)
-	prevGame := game.DeepCopy()
 
 	stateSize := len(gs.States)
 	undoState := gs.Undo()


### PR DESCRIPTION
closes #29 

There are several tests that started failing.  

It happened because I am not starting on the correct card in the deck (3rd one) instead of the first one.

I also had forgotten to add FlipCount to the IsEqual check.

Updated the save state check to check the second to last state instead of using a constant for the index.